### PR TITLE
Fix typos in chat session utilities

### DIFF
--- a/src/casual_mcp_chat/app.py
+++ b/src/casual_mcp_chat/app.py
@@ -6,7 +6,7 @@ from casual_mcp.models import UserMessage
 from dotenv import load_dotenv
 
 from casual_mcp_chat.session import Session
-from casual_mcp_chat.utils import create_new_session, handle_chat_messsage
+from casual_mcp_chat.utils import create_new_session, handle_chat_message
 
 default_system_prompt = """You are a helpful assistant.
 
@@ -93,8 +93,8 @@ show_tool_calls = st.sidebar.checkbox("Show Tool Calls", value=False)
 
 async def main():
     # Display chat history
-    for message in session.messsages:
-        handle_chat_messsage(message, show_tool_calls)
+    for message in session.messages:
+        handle_chat_message(message, show_tool_calls)
 
     # Handle new user input
     if prompt := st.chat_input("How can I help?"):
@@ -110,18 +110,18 @@ async def main():
 
         # Generate User Message, add to session and display
         user_message = UserMessage(content=prompt)
-        session.messsages.append(user_message)
-        handle_chat_messsage(user_message)
+        session.messages.append(user_message)
+        handle_chat_message(user_message)
 
         # Run tool-calling chat loop
         response_messages = await chat.chat(
-            session.messsages.copy(),
+            session.messages.copy(),
         )
 
         # Display assistant responses + store them
         for message in response_messages:
-            handle_chat_messsage(message, show_tool_calls)
+            handle_chat_message(message, show_tool_calls)
 
-        session.messsages.extend(response_messages)
+        session.messages.extend(response_messages)
 
 asyncio.run(main())

--- a/src/casual_mcp_chat/session.py
+++ b/src/casual_mcp_chat/session.py
@@ -3,6 +3,6 @@ from pydantic import BaseModel
 
 
 class Session(BaseModel):
-    model: str | None = None,
-    system_prompt: str | None = None,
-    messsages: list[ChatMessage] = []
+    model: str | None = None
+    system_prompt: str | None = None
+    messages: list[ChatMessage] = []

--- a/src/casual_mcp_chat/utils.py
+++ b/src/casual_mcp_chat/utils.py
@@ -15,7 +15,7 @@ def create_new_session(
         system_prompt=system_prompt
     )
 
-def handle_chat_messsage(message: ChatMessage, show_tool_calls: bool = False):
+def handle_chat_message(message: ChatMessage, show_tool_calls: bool = False):
     if not message.role in ['user', 'assistant']:
         return
 


### PR DESCRIPTION
## Summary
- fix typo `messsages` -> `messages` in `Session`
- fix typo `handle_chat_messsage` -> `handle_chat_message`
- use corrected names throughout the app

## Testing
- `ruff check`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684309e53d2483299aad4045955139d6