### PR TITLE
Add first-run defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 A Streamlit-based chat interface for [Casual MCP](https://github.com/alexstansfield/casual-mcp).
 
 Install with `pip install casual-mcp-chat` and run using the `casual-mcp-chat` command
+
+On first run the CLI will create a `prompt-templates` directory and a
+`casual_mcp_config.json` file in the current working directory if they do not
+already exist. The default system prompt template is copied into the new
+directory so you can start chatting immediately.

--- a/src/casual_mcp_chat/cli.py
+++ b/src/casual_mcp_chat/cli.py
@@ -3,8 +3,11 @@ from pathlib import Path
 
 from streamlit.web import cli as stcli
 
+from casual_mcp_chat.utils import ensure_default_files
+
 
 def app():
+    ensure_default_files()
     app_path = Path(__file__).parent / "app.py"
     sys.argv = ["streamlit", "run", str(app_path)]
     sys.exit(stcli.main())

--- a/src/casual_mcp_chat/utils.py
+++ b/src/casual_mcp_chat/utils.py
@@ -1,25 +1,25 @@
+import shutil
 from pathlib import Path
-import streamlit as st
 
+import streamlit as st
 from casual_mcp.models import ChatMessage
 
 from casual_mcp_chat.session import Session
 
-TEMPLATES_DIR = Path("prompt-templates")
-
-def get_available_templates() -> list[str]:
-    return [
-        f.stem  # filename without .j2 extension
-        for f in TEMPLATES_DIR.glob("*.j2")
-    ]
-
-def get_template_content(template_name) -> str:
-    # Load the selected template content
-    template_path = TEMPLATES_DIR / f"{template_name}.j2"
-    template_content = template_path.read_text()
-    return template_content
+FILES_DIR = Path(__file__).parent / "files"
 
 TEMPLATES_DIR = Path("prompt-templates")
+
+
+def ensure_default_files() -> None:
+    """Ensure default config and templates exist in the current directory."""
+    if not TEMPLATES_DIR.exists():
+        TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+        shutil.copy(FILES_DIR / "default.j2", TEMPLATES_DIR / "default.j2")
+
+    config_path = Path("casual_mcp_config.json")
+    if not config_path.exists():
+        shutil.copy(FILES_DIR / "casual_mcp_config.json", config_path)
 
 def get_available_templates() -> list[str]:
     return [


### PR DESCRIPTION
## Summary
- copy default config and template if missing on startup
- document first run behaviour

## Testing
- `ruff check src/casual_mcp_chat/cli.py src/casual_mcp_chat/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685188a4d00c8329be4fdbd4d3824fa9